### PR TITLE
enhance PostTLS's installability and distributability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Python binaries
 *.py[cod]
- 
+
 # Temporary GNU Emacs files
 *~
 [#]*[#]
@@ -17,3 +17,7 @@ docs/_build
 
 # Database
 posttls/config/db.sqlite3
+
+# Source Distribution and respective egg
+dist/
+posttls.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README.md
+include requirements.txt
+recursive-include posttls/core/static/css *
+recursive-include posttls/core/static/vendor *
+recursive-include posttls/core/static/vendor/bootstrap/css *
+recursive-include posttls/core/static/vendor/bootstrap/fonts *
+recursive-include posttls/core/static/vendor/bootstrap/js *
+recursive-include posttls/core/templates/core *

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export POSTTLS_MEDIA_ROOT_DIR="/home/hendrik/apps/posttls/media/"
 export POSTTLS_ENVIRONMENT_TYPE="development"
 
 # PostTLS settings
+export POSTTLS_NOTIFICATION_SYSADMIN_MAIL_ADDRESS="admin@localhost"
 export POSTTLS_NOTIFICATION_SENDER="postmaster@domain.com (Postmaster)"
 export POSTTLS_NOTIFICATION_SMTP_HOST="localhost"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The code in this repository is licensed under version 3 of the GNU Affero Genera
 Requirements
 ------------
 
-Please be aware that PostTLS right now is in **early stage** and there are quite a few things to prepare on the server to use the software. You should be familiar with Linux system administration and you should know how to run a python program in production. In the following you will find a list of requirements - but this is **not a step-by-step guide to meet these requirements**! Of course, documentation and automation of the installation procedure will be enhanced in the future if there is demand. 
+Please be aware that PostTLS right now is in **early stage** and there are quite a few things to prepare on the server to use the software. You should be familiar with Linux system administration and you should know how to run a python program in production. In the following you will find a list of requirements - but this is **not a step-by-step guide to meet these requirements**! Of course, documentation and automation of the installation procedure will be enhanced in the future if there is demand.
 
 **USE THIS SOFTWARE AT YOUR OWN RISK! AND MAKE SURE YOU UNDERSTAND WHAT IT DOES!**
 
@@ -20,15 +20,15 @@ Make sure to meet the following requirements:
 - Python 3
 - Virtualenv and virtualenvwrapper
 - Two Postfix instances. See [Managing multiple Postfix instances on a single host](http://www.postfix.org/MULTI_INSTANCE_README.html) to find out more about multiple instance support of Postfix.
-  - First instance: Postfix option `smtp_tls_security_level` is set to `encrypt` and implements mandatory TLS for all domains. 
+  - First instance: Postfix option `smtp_tls_security_level` is set to `encrypt` and implements mandatory TLS for all domains.
   - Second instance: Postfix option `smtp_tls_security_level` is set to `may` and implements opportunistic TLS.
 - PostTLS calls some Postfix commands, which should be executable via sudo without password. So add something like this to /etc/sudoers using `sudo visudo`:
 
 ```bash
-# User hendrik can use apps needed for PostTLS
-hendrik ALL = NOPASSWD: /usr/bin/mailq
-hendrik ALL = NOPASSWD: /usr/sbin/postcat
-hendrik ALL = NOPASSWD: /usr/sbin/postsuper
+# User 'developer' can use apps needed for PostTLS
+developer ALL = NOPASSWD: /usr/bin/mailq
+developer ALL = NOPASSWD: /usr/sbin/postcat
+developer ALL = NOPASSWD: /usr/sbin/postsuper
 ```
 
 Installation
@@ -53,8 +53,8 @@ Configuration of PostTLS is done via environment variables. You can use a bash s
 ```bash
 # Django configuration
 export POSTTLS_SECRET_KEY="verysecretkey"
-export POSTTLS_STATIC_ROOT_DIR="/home/hendrik/apps/posttls/static/"
-export POSTTLS_MEDIA_ROOT_DIR="/home/hendrik/apps/posttls/media/"
+export POSTTLS_STATIC_ROOT_DIR="/home/developer/apps/posttls/static/"
+export POSTTLS_MEDIA_ROOT_DIR="/home/developer/apps/posttls/media/"
 
 # Set this to 'production' in production environment (see Django settings file)
 export POSTTLS_ENVIRONMENT_TYPE="development"
@@ -89,4 +89,4 @@ Automation
 
 You can configure a cron job to process the queue once every minute. To prevent overlapping of cron jobs, use the [flock](http://linux.die.net/man/1/flock) command:
 
-    */1 * * * * . /home/hendrik/apps/posttls/env.sh && /usr/bin/flock -w 0 /home/hendrik/apps/posttls/cron.lock /home/hendrik/.virtualenvs/posttls/bin/python3 /home/hendrik/apps/posttls/posttls/posttls/manage.py process_queue >/dev/null 2>&1
+    */1 * * * * . /home/developer/apps/posttls/env.sh && /usr/bin/flock -w 0 /home/developer/apps/posttls/cron.lock /home/developer/.virtualenvs/posttls/bin/python3 /home/developer/apps/posttls/posttls/posttls/manage.py process_queue >/dev/null 2>&1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     license='AGPLv3',
-    description='Postfix' Transport Encryption under Control of the User',
+    description="Postfix' Transport Encryption under Control of the User",
     long_description=README.md,
     url='https://posttls.com/',
     author='Hendrik Suenkler',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
-    name='django-posttls',
+    name='posttls',
     version='1.0',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+import os
+from setuptools import find_packages, setup
+
+with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
+    README = readme.read()
+
+# allow setup.py to be run from any path
+os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+
+setup(
+    name='django-posttls',
+    version='1.0',
+    packages=find_packages(),
+    include_package_data=True,
+    license='AGPLv3',
+    description='Postfix' Transport Encryption under Control of the User',
+    long_description=README.md,
+    url='https://posttls.com/',
+    author='Hendrik Suenkler',
+    author_email='hendrik@posttls.com',
+    classifiers=[
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: AGPLv3',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,32 @@
 import os
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
+with open(os.path.join(os.path.dirname(__file__), "README.md")) as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
-    name='posttls',
-    version='1.0',
+    name="posttls",
+    version="1.0",
     packages=find_packages(),
     include_package_data=True,
-    license='AGPLv3',
+    license="AGPLv3",
     description="Postfix' Transport Encryption under Control of the User",
     long_description=README,
-    url='https://posttls.com/',
-    author='Hendrik Suenkler',
-    author_email='hendrik@posttls.com',
+    url="https://posttls.com/",
+    author="Hendrik Suenkler",
+    author_email="hendrik@posttls.com",
     classifiers=[
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: AGPLv3',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Internet :: WWW/HTTP',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Framework :: Django :: 1.8",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: AGPLv3",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     license="AGPLv3",
-    description="Postfix' Transport Encryption under Control of the User",
+    description="Postfix's Transport Encryption under Control of the User",
     long_description=README,
     url="https://posttls.com/",
     author="Hendrik Suenkler",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     license='AGPLv3',
     description="Postfix' Transport Encryption under Control of the User",
-    long_description=README.md,
+    long_description=README,
     url='https://posttls.com/',
     author='Hendrik Suenkler',
     author_email='hendrik@posttls.com',


### PR DESCRIPTION
This should enable the creation of source distributions which can be installed using pip.

You can make a source distribution by executing
> $ python setup.py sdist

in the project's main folder.

Plus this PR adds a missing environment variable to README.md.